### PR TITLE
test(controller): switch to headless mode to please Linux.

### DIFF
--- a/lib/controller-with-max-size-window.test.ts
+++ b/lib/controller-with-max-size-window.test.ts
@@ -1,5 +1,6 @@
 import * as SUT from './controller';
 import { LaunchOptions } from './actions';
+
 describe('Puppeteer Controller', (): void => {
   let pptc: SUT.PuppeteerController;
   beforeEach((): void => {
@@ -10,7 +11,7 @@ describe('Puppeteer Controller', (): void => {
   test('should start with max sized window', async (): Promise<void> => {
     // Given
     const launchOptions: LaunchOptions = {
-      headless: false,
+      headless: true,
     };
     const url = 'https://reactstrap.github.io/components/form';
 


### PR DESCRIPTION
@hdorgeval, I reproduced the issue locally: the test fails with the same error.

It seems that by simply setting headless mode to `true`, the issue is fixed. I'm not sure if the suppression of the headless mode for this specific test was intentional or not; I suppose you did it for development purposes only.

Note that when the headless mode is set to `false`, I do see Chrome window opening with two tabs (the first one remaining at about:blank). I would expect the window to be maximized, but it just stays in the corner of the screen, and then the test fails.