### PR TITLE
update: reduce wait time

### DIFF
--- a/lib/actions/handle-actions/has-handle-moved/has-handle-moved.test.ts
+++ b/lib/actions/handle-actions/has-handle-moved/has-handle-moved.test.ts
@@ -79,7 +79,7 @@ describe('selector has moved', (): void => {
     const page = await browser.newPage();
     await page.goto(`file:${path.join(__dirname, 'has-handle-moved.test2.html')}`);
     const handle = await page.$('#moving');
-    await page.waitFor(2000); // wait twice the animation duration
+    await page.waitFor(500); // wait twice the animation duration
     const previousClientRectangle = await SUT.getClientRectangleOfHandle(handle);
 
     // When


### PR DESCRIPTION
Hello!
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted to 500 milliseconds, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving an average of 11.1% in test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.